### PR TITLE
Implement automatic selection of default model on load

### DIFF
--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -157,9 +157,7 @@ export const inferenceRequest = async (
   return handleAxios<ApiModelData[]>(request);
 };
 
-export const fetchModelMetadata = async (
-  backendUrl: string,
-): Promise<SetStateAction<never[]>> => {
+export const fetchModelMetadata = async (backendUrl: string): Promise<any> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 import { AzureAPIError, ValueError } from "./error";
-import { ApiModelData, Images } from "./types";
-import { SetStateAction } from "react";
+import { ApiModelData, Images, ModelMetadata } from "./types";
 
 const handleAxios = async <T>(request: {
   method: string;
@@ -157,7 +156,9 @@ export const inferenceRequest = async (
   return handleAxios<ApiModelData[]>(request);
 };
 
-export const fetchModelMetadata = async (backendUrl: string): Promise<any> => {
+export const fetchModelMetadata = async (
+  backendUrl: string,
+): Promise<ModelMetadata[]> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
@@ -170,5 +171,5 @@ export const fetchModelMetadata = async (backendUrl: string): Promise<any> => {
     },
     data: {},
   };
-  return handleAxios<SetStateAction<never[]>>(request);
+  return handleAxios<ModelMetadata[]>(request);
 };

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -40,3 +40,8 @@ export interface ApiModelData {
   };
   totalBoxes: number;
 }
+
+export interface ModelMetadata {
+  model_name: string;
+  default?: boolean;
+}

--- a/src/root/body/body.tsx
+++ b/src/root/body/body.tsx
@@ -257,8 +257,14 @@ const Body: React.FC<params> = (props) => {
 
     if (process.env.REACT_APP_MODE !== "test") {
       fetchModelMetadata(backendUrl)
-        .then((data) => {
-          setMetadata(data);
+        .then((metadata) => {
+          setMetadata(metadata);
+
+          // Find the default model from the metadata
+          const defaultModel = metadata.find((model: any) => model.default);
+          if (defaultModel) {
+            setSelectedModel(defaultModel.model_name);
+          }
         })
         .catch((error) => {
           console.error(error);


### PR DESCRIPTION
- Updated the model metadata fetch logic to automatically identify and select a default model when the metadata is loaded.
- If a 'default' attribute is present and set to true for any model, that model is pre-selected.

#111