### PR TITLE
144-Full-Resolution-Capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/_versions.ts
+++ b/src/_versions.ts
@@ -9,10 +9,10 @@ export interface TsAppVersion {
     gitTag?: string;
 };
 export const versions: TsAppVersion = {
-    version: '0.8.1',
+    version: '0.8.2',
     name: 'nachet-frontend',
-    versionDate: '2024-05-03T01:54:41.684Z',
-    gitCommitHash: '344fefa',
-    versionLong: '0.8.1-344fefa',
+    versionDate: '2024-05-08T01:56:33.233Z',
+    gitCommitHash: 'eecd9cd',
+    versionLong: '0.8.2-eecd9cd',
 };
 export default versions;

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -250,12 +250,13 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
             height={height}
             style={{ objectFit: "cover" }}
             videoConstraints={{
-              width: width,
-              height,
+              width: 1920,
+              height: 1080,
               deviceId: activeDeviceId,
             }}
             screenshotFormat="image/png"
             screenshotQuality={1}
+            forceScreenshotSourceSize={true}
           />
         ) : (
           <>

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -246,9 +246,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
           <Webcam
             ref={webcamRef}
             mirrored={false}
-            width={width}
-            height={height}
-            style={{ objectFit: "cover" }}
+            width="100%"
+            height="100%"
+            style={{ objectFit: "fill" }}
             videoConstraints={{
               width: 1920,
               height: 1080,


### PR DESCRIPTION
The problem was that we were constraining the video feed size when we did not have to. React-Webcam supports specifying the full resolution and down scaling it for view purposes without decreasing the screenshot resolution  
  
This PR
Fixes #144   so that screenshots are 1920x1080 instead of the scaled down canvas element in the browser
Fixes #54     so that the feed shows the full camera feed 
- resulting in black bars if the shape of the image input is different from the canvas container
- this is purely visual and will not show up in saved images or in the image submitted for inference

video feed screenshot
![image](https://github.com/ai-cfia/nachet-frontend/assets/78883122/8baf1d6d-e845-4882-bb06-a303a9caa0d7)


Saved image prior to this fix
![testforcetrue-2024-5-7](https://github.com/ai-cfia/nachet-frontend/assets/78883122/6a00cc03-5b8a-4c84-8efb-d56608441088)


Saved image after fix
![testforcetrue2-2024-5-7](https://github.com/ai-cfia/nachet-frontend/assets/78883122/ceda5c15-a39b-4955-9d89-285e97abf538)

  