### PR TITLE
147 batch upload init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.8.5",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/_versions.ts
+++ b/src/_versions.ts
@@ -9,10 +9,10 @@ export interface TsAppVersion {
     gitTag?: string;
 };
 export const versions: TsAppVersion = {
-    version: '0.8.5',
+    version: '0.9.0',
     name: 'nachet-frontend',
-    versionDate: '2024-06-05T14:39:44.056Z',
-    gitCommitHash: '9074593',
-    versionLong: '0.8.5-9074593',
+    versionDate: '2024-06-22T20:47:06.767Z',
+    gitCommitHash: '',
+    versionLong: '0.9.0-',
 };
 export default versions;

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -3,11 +3,13 @@ import { AzureAPIError, ValueError } from "./error";
 import {
   ApiInferenceData,
   ApiSpeciesData,
+  BatchUploadMetadata,
   FeedbackDataNegative,
   FeedbackDataPositive,
   Images,
   ModelMetadata,
 } from "./types";
+import { b } from "vitest/dist/suite-a18diDsI";
 
 const handleAxios = async <T>(request: {
   method: string;
@@ -290,4 +292,99 @@ export const requestClassList = async (
     // },
   };
   return handleAxios<ApiSpeciesData>(request);
+};
+
+export const batchUploadInit = async (
+  backendUrl: string,
+  uuid: string,
+  containerUuid: string,
+  nbPictures: number,
+): Promise<{
+  session_id: string;
+}> => {
+  if (backendUrl === "" || backendUrl == null) {
+    throw new ValueError("Backend URL is null or empty");
+  }
+  if (uuid === "" || uuid == null) {
+    throw new ValueError("UUID is null or empty");
+  }
+  if (containerUuid === "" || containerUuid == null) {
+    throw new ValueError("Container UUID is null or empty");
+  }
+  if (nbPictures === 0 || nbPictures == null) {
+    throw new ValueError("Number of pictures is null or empty");
+  }
+  const request = {
+    method: "post",
+    url: `${backendUrl}/new-batch-import`,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    },
+    data: {
+      user_id: uuid,
+      container_name: containerUuid,
+      nb_pictures: nbPictures,
+    },
+  };
+  return handleAxios<{
+    session_id: string;
+  }>(request);
+};
+
+export const batchUploadImage = async (
+  backendUrl: string,
+  data: BatchUploadMetadata,
+): Promise<boolean> => {
+  const {
+    containerName,
+    uuid,
+    seedId,
+    zoom,
+    seedCount,
+    sessionId,
+    imageDataUrl,
+  } = data;
+  if (backendUrl === "" || backendUrl == null) {
+    throw new ValueError("Backend URL is null or empty");
+  }
+  if (sessionId === "" || sessionId == null) {
+    throw new ValueError("Session ID is null or empty");
+  }
+  if (imageDataUrl === "" || imageDataUrl == null) {
+    throw new ValueError("Image is null or empty");
+  }
+  if (containerName === "" || containerName == null) {
+    throw new ValueError("Container name is null or empty");
+  }
+  if (uuid === "" || uuid == null) {
+    throw new ValueError("UUID is null or empty");
+  }
+  if (seedId === "" || seedId == null) {
+    throw new ValueError("Seed ID is null or empty");
+  }
+  if (zoom === 0 || zoom == null) {
+    throw new ValueError("Zoom is null or empty");
+  }
+  if (seedCount === 0 || seedCount == null) {
+    throw new ValueError("Seed count is null or empty");
+  }
+  const request = {
+    method: "post",
+    url: `${backendUrl}/upload-picture`,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    },
+    data: {
+      container_name: containerName,
+      user_id: uuid,
+      seed_id: seedId,
+      zoom_level: zoom,
+      nb_seeds: seedCount,
+      session_id: sessionId,
+      image: imageDataUrl,
+    },
+  };
+  return handleAxios(request);
 };

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -339,6 +339,7 @@ export const batchUploadImage = async (
     containerName,
     uuid,
     seedId,
+    seedName, // TODO: remove when backend is implemented
     zoom,
     seedCount,
     sessionId,
@@ -379,6 +380,7 @@ export const batchUploadImage = async (
       container_name: containerName,
       user_id: uuid,
       seed_id: seedId,
+      seed_name: seedName, // TODO: remove when backend is implemented
       zoom_level: zoom,
       nb_seeds: seedCount,
       session_id: sessionId,

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -42,38 +42,6 @@ const handleAxios = async <T>(request: {
   return data;
 };
 
-const handleAxiosPost = async <T>(request: {
-  method: string;
-  url: string;
-  headers: { [label: string]: string };
-  data: any;
-}): Promise<T> => {
-  const data = await axios.post(request.url, request.data, request.headers)
-    .then((response) => {
-      if (response.status === 200) {
-        return response.data;
-      } else {
-        throw new AzureAPIError(response.data);
-      }
-    })
-    .catch((error) => {
-      if (error.response) {
-        console.error(error.response.data);
-        console.error(error.response.status);
-        console.error(error.response.headers);
-        throw new AzureAPIError(error.response.data);
-      } else if (error.request) {
-        console.error(error.request);
-        throw new AzureAPIError(error.request);
-      } else {
-        console.error("Error", error.message);
-      }
-      console.error(error.config);
-      throw new AzureAPIError(error.config);
-    });
-  return data;
-};
-
 export const readAzureStorageDir = async (
   backendUrl: string,
   uuid: string,
@@ -366,7 +334,6 @@ export const batchUploadInit = async (
 export const batchUploadImage = async (
   backendUrl: string,
   data: BatchUploadMetadata,
-  setProgress: (progress: number) => void,
 ): Promise<boolean> => {
   const {
     containerName,
@@ -419,11 +386,6 @@ export const batchUploadImage = async (
       session_id: sessionId,
       image: imageDataUrl,
     },
-    onUploadProgress: (progressEvent: ProgressEvent) => {
-      const progress = (progressEvent.loaded / progressEvent.total) * 100;
-      console.log(`Upload Progress: ${progress}%`);
-      setProgress(progress);
-    },
   };
-  return handleAxiosPost(request);
+  return handleAxios(request);
 };

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -9,6 +9,7 @@ import {
   Images,
   ModelMetadata,
 } from "./types";
+import { b } from "vitest/dist/suite-a18diDsI";
 
 const handleAxios = async <T>(request: {
   method: string;

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -9,7 +9,6 @@ import {
   Images,
   ModelMetadata,
 } from "./types";
-import { b } from "vitest/dist/suite-a18diDsI";
 
 const handleAxios = async <T>(request: {
   method: string;

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -33,4 +33,18 @@ class ValueError extends Error {
   }
 }
 
-export { DecodeError, FetchError, BlobError, AzureAPIError, ValueError };
+class UploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UploadError";
+  }
+}
+
+export {
+  DecodeError,
+  FetchError,
+  BlobError,
+  AzureAPIError,
+  ValueError,
+  UploadError,
+};

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -106,3 +106,13 @@ export interface ModelMetadata {
   pipeline_name: string;
   default?: boolean;
 }
+
+export interface BatchUploadMetadata {
+  containerName: string;
+  uuid: string;
+  seedId: string;
+  zoom: number;
+  seedCount: number;
+  imageDataUrl: string;
+  sessionId: string;
+}

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -111,6 +111,7 @@ export interface BatchUploadMetadata {
   containerName: string;
   uuid: string;
   seedId: string;
+  seedName: string; // TODO: remove when backend is implemented
   zoom: number;
   seedCount: number;
   imageDataUrl: string;

--- a/src/components/body/batch_upload_popup/BatchUploadPopup.tsx
+++ b/src/components/body/batch_upload_popup/BatchUploadPopup.tsx
@@ -43,10 +43,8 @@ export const InfoContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding-left: 1vw;
-  padding-right: 1vw;
-  margin-top: 1vh;
-  margin-bottom: 3vh;
+  min-width: 100%;
+  width: 100%;
 `;
 
 interface params {
@@ -73,6 +71,9 @@ const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
   const [sessionId, setSessionId] = React.useState<string>("");
 
   const classList: ClassData[] = useMemo(() => {
+    if (backendUrl === "" || backendUrl == null) {
+      return [];
+    };
     const classes: ClassData[] = [];
     const getClasses = () => {
       return requestClassList(backendUrl).then((response) => {
@@ -217,7 +218,7 @@ const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
     <Overlay>
       <Box
         sx={{
-          width: "20vw",
+          width: "fit-content",
           height: "fit-content",
           zIndex: 30,
           border: `0.01vh solid LightGrey`,
@@ -241,7 +242,9 @@ const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
               <CloseIcon />
             </IconButton>
           }
-          sx={{ padding: "0.8vh 0.8vh 0.8vh 0.8vh" }}
+          sx={{
+            width: "100%",
+           }}
         />
         <InfoContainer>
           <FormControl>
@@ -276,7 +279,7 @@ const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
               freeSolo={false}
               getOptionLabel={getClassLabel}
               sx={{
-                marginTop: "20px",
+                marginTop: "5px",
                 width: "100%",
               }}
             />
@@ -286,6 +289,10 @@ const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
               variant="outlined"
               type="number"
               onChange={(e) => setSeedCount(parseInt(e.target.value))}
+              sx={{
+                marginTop: "5px",
+                width: "100%",
+              }}
             />
             <TextField
               id="zoom-level"
@@ -293,6 +300,10 @@ const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
               variant="outlined"
               type="number"
               onChange={(e) => setZoom(parseInt(e.target.value))}
+              sx={{
+                marginTop: "5px",
+                width: "100%",
+              }}
             />
             <TextField
               id="file-input"
@@ -303,6 +314,10 @@ const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
                 multiple: true,
               }}
               onChange={handleChange}
+              sx={{
+                marginTop: "5px",
+                width: "100%",
+              }}
             />
             {/* <input
             type="file"

--- a/src/components/body/batch_upload_popup/BatchUploadPopup.tsx
+++ b/src/components/body/batch_upload_popup/BatchUploadPopup.tsx
@@ -1,0 +1,222 @@
+import styled from "styled-components";
+import {
+  Box,
+  Button,
+  CardHeader,
+  FormControl,
+  IconButton,
+  Input,
+  TextField,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { colours } from "../../../styles/colours";
+import React from "react";
+import { useBackendUrl } from "../../../hooks";
+import { batchUploadImage, batchUploadInit } from "../../../common/api";
+import { BatchUploadMetadata } from "../../../common/types";
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 20;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition:
+    visibility 0.5s,
+    opacity 0.5s;
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-left: 1vw;
+  padding-right: 1vw;
+  margin-top: 1vh;
+  margin-bottom: 3vh;
+`;
+
+interface params {
+  setBatchUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  backendUrl: string;
+  containerName: string;
+  uuid: string;
+}
+
+const BatchUploadPopup: React.FC<params> = (props): JSX.Element => {
+  const { setBatchUploadOpen, containerName, uuid, backendUrl } = props;
+
+  const [files, setFiles] = React.useState<FileList | null>(null);
+  const [uploading, setUploading] = React.useState<boolean>(false);
+  const [uploadProgress, setUploadProgress] = React.useState<number>(0);
+  const [uploadError, setUploadError] = React.useState<string | null>(null);
+
+  const [seedId, setSeedId] = React.useState<string>("");
+  const [zoom, setZoom] = React.useState<number>(1);
+  const [seedCount, setSeedCount] = React.useState<number>(0);
+  const [sessionId, setSessionId] = React.useState<string>("");
+
+  const uploadImage = (file: File): void => {
+      if (file !== undefined) {
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          if (typeof reader.result !== "string") {
+            return;
+          }
+          const data: BatchUploadMetadata = {
+            containerName: containerName,
+            uuid: uuid,
+            seedId: seedId,
+            zoom: zoom,
+            seedCount: seedCount,
+            imageDataUrl: reader.result,
+            sessionId: sessionId,
+          };
+          batchUploadImage(backendUrl, data).then((response) => {
+            if (response) {
+              console.log("Successfully uploaded image: ", file.name);
+            }
+            setUploadProgress((prev) => prev + 1);
+          }).catch((error) => {
+            console.error("Error uploading image: ", file.name);
+            throw error;
+          });
+        };
+        reader.readAsDataURL(file);
+      };
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    // TODO validation
+    const files = event.target.files;
+    if (files !== null) {
+      console.log(files);
+      setFiles(files);
+    }
+  };
+
+  const handleUpload = (): void => {
+    if (files === null) {
+      return;
+    }
+    batchUploadInit(backendUrl, uuid, containerName, files.length)
+      .then((response) => {
+        setSessionId(response.session_id);
+        setUploading(true);
+        setUploadProgress(0);
+        setUploadError(null);
+      })
+      .catch((error) => {
+        setUploadError(error.toString());
+      });
+    setUploading(false);
+  };
+
+  const handleClose = (): void => {
+    setBatchUploadOpen(false);
+  };
+
+  return (
+    <Overlay>
+      <Box
+        sx={{
+          width: "20vw",
+          height: "fit-content",
+          zIndex: 30,
+          border: `0.01vh solid LightGrey`,
+          borderRadius: 1,
+          background: colours.CFIA_Background_White,
+        }}
+        boxShadow={1}
+      >
+        <CardHeader
+          title="Load Image"
+          titleTypographyProps={{
+            variant: "h6",
+            align: "left",
+            fontWeight: 600,
+            fontSize: "1.3vh",
+            color: colours.CFIA_Font_Black,
+            zIndex: 30,
+          }}
+          action={
+            <IconButton onClick={handleClose}>
+              <CloseIcon />
+            </IconButton>
+          }
+          sx={{ padding: "0.8vh 0.8vh 0.8vh 0.8vh" }}
+        />
+        <InfoContainer>
+          <FormControl>
+            <TextField
+              id="outlined-basic"
+              label="Outlined"
+              variant="outlined"
+              type="file"
+              inputProps={{
+                multiple: true,
+              }}
+              onChange={handleChange}
+            />
+            {/* <input
+            type="file"
+            onChange={uploadImage}
+            style={{
+              minWidth: "100%",
+              width: "100%",
+              fontSize: "0.7vw",
+            }}
+            multiple
+          /> */}
+
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-evenly",
+                alignItems: "center",
+                marginTop: "20px",
+              }}
+            >
+              <Button
+                sx={{
+                  backgroundColor: "green",
+                  color: "white",
+                  "&:hover": {
+                    backgroundColor: "green",
+                    opacity: 0.6,
+                  },
+                  marginRight: "10px",
+                }}
+                onClick={handleUpload}
+              >
+                Upload
+              </Button>
+              <Button
+                sx={{
+                  backgroundColor: "red",
+                  color: "white",
+                  "&:hover": {
+                    backgroundColor: "red",
+                    opacity: 0.5,
+                  },
+                }}
+                onClick={handleClose}
+              >
+                Cancel
+              </Button>
+            </Box>
+          </FormControl>
+        </InfoContainer>
+      </Box>
+    </Overlay>
+  );
+};
+
+export default BatchUploadPopup;

--- a/src/components/body/batch_upload_popup/index.ts
+++ b/src/components/body/batch_upload_popup/index.ts
@@ -1,2 +1,2 @@
-import BatchUploadPopup from './BatchUploadPopup';
+import BatchUploadPopup from "./BatchUploadPopup";
 export default BatchUploadPopup;

--- a/src/components/body/batch_upload_popup/index.ts
+++ b/src/components/body/batch_upload_popup/index.ts
@@ -1,0 +1,2 @@
+import BatchUploadPopup from './BatchUploadPopup';
+export default BatchUploadPopup;

--- a/src/components/body/feedback_form/FeedbackForm.tsx
+++ b/src/components/body/feedback_form/FeedbackForm.tsx
@@ -120,8 +120,6 @@ export const NegativeFeedbackForm = (
   const { inference, position, classList, onCancel, onSubmit } = props;
   const [selectedClass, setSelectedClass] = useState<ClassData>(defaultClass);
   const [comment, setComment] = useState<string>(reasons[2]);
-  const [slassDropdownEnabled, setClassDropdownEnabled] =
-    useState<boolean>(true);
 
   const filter = createFilterOptions<ClassData>();
 
@@ -207,9 +205,6 @@ export const NegativeFeedbackForm = (
         classId: "",
         label: "",
       });
-      setClassDropdownEnabled(false);
-    } else {
-      setClassDropdownEnabled(true);
     }
   }, [comment]);
 
@@ -256,7 +251,7 @@ export const NegativeFeedbackForm = (
               marginTop: "20px",
               width: "100%",
             }}
-            disabled={!slassDropdownEnabled}
+            disabled={comment === "No Seed"}
           />
           <Select
             labelId="comment-select-label"

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -38,6 +38,7 @@ interface MicroscopeFeedProps {
   setSwitchDeviceOpen: React.Dispatch<React.SetStateAction<boolean>>;
   canvasRef: React.RefObject<HTMLCanvasElement>;
   setSaveOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setBatchUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setSwitchModelOpen: React.Dispatch<React.SetStateAction<boolean>>;
   imageCache: Images[];
@@ -108,6 +109,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
     setSwitchDeviceOpen,
     canvasRef,
     setSaveOpen,
+    setBatchUploadOpen,
     setUploadOpen,
     setSwitchModelOpen,
     imageCache,
@@ -329,6 +331,14 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
           disabled={!isWebcamActive} // Disable when the webcam is active
           onClick={() => {
             setSwitchDeviceOpen(true);
+          }}
+        />
+        <ButtonMicroscopeFeed
+          label="BATCH"
+          icon={<UploadFileIcon color="inherit" style={iconStyle} />}
+          disabled={isWebcamActive} // Disable when the webcam is active
+          onClick={() => {
+            setBatchUploadOpen(true);
           }}
         />
         <ButtonMicroscopeFeed

--- a/src/pages/classifier/index.tsx
+++ b/src/pages/classifier/index.tsx
@@ -22,6 +22,7 @@ interface params {
   savedImages: any[];
   clearImageCache: () => void;
   setImageIndex: React.Dispatch<React.SetStateAction<number>>;
+  setBatchUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
   canvasRef: React.RefObject<HTMLCanvasElement>;
   handleInference: () => void;
@@ -73,6 +74,7 @@ const Classifier: React.FC<params> = (props) => {
             setSwitchModelOpen={props.setSwitchModelOpen}
             imageCache={props.savedImages}
             imageIndex={props.imageIndex}
+            setBatchUploadOpen={props.setBatchUploadOpen}
             setUploadOpen={props.setUploadOpen}
             isWebcamActive={props.isWebcamActive}
             onCaptureClick={props.onCaptureClick}

--- a/src/root/body/body.tsx
+++ b/src/root/body/body.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../common";
 import { Images, LabelOccurrences, ModelMetadata } from "../../common/types";
 import Cookies from "js-cookie";
+import BatchUploadPopup from "../../components/body/batch_upload_popup";
 
 interface params {
   windowSize: {
@@ -52,6 +53,7 @@ const Body: React.FC<params> = (props) => {
   const [imageFormat, setImageFormat] = useState<string>("image/png");
   const [imageLabel, setImageLabel] = useState<string>("");
   const [saveOpen, setSaveOpen] = useState(false);
+  const [batchUploadOpen, setBatchUploadOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [modelInfoPopupOpen, setModelInfoPopupOpen] = useState(false);
   const [switchDeviceOpen, setSwitchDeviceOpen] = useState(false);
@@ -323,6 +325,11 @@ const Body: React.FC<params> = (props) => {
           saveIndividualImage={saveIndividualImage}
         />
       )}
+      {batchUploadOpen && (
+        <BatchUploadPopup
+          setBatchUploadOpen={setBatchUploadOpen}
+        />
+      )}
       {uploadOpen && (
         <UploadPopup
           setUploadOpen={setUploadOpen}
@@ -378,6 +385,7 @@ const Body: React.FC<params> = (props) => {
       <Classifier
         handleInference={handleInferenceRequest}
         imageIndex={imageIndex}
+        setBatchUploadOpen={setBatchUploadOpen}
         setUploadOpen={setUploadOpen}
         imageSrc={imageSrc}
         webcamRef={webcamRef}

--- a/src/root/body/body.tsx
+++ b/src/root/body/body.tsx
@@ -328,6 +328,9 @@ const Body: React.FC<params> = (props) => {
       {batchUploadOpen && (
         <BatchUploadPopup
           setBatchUploadOpen={setBatchUploadOpen}
+          backendUrl={backendUrl}
+          uuid={props.uuid}
+          containerName={props.uuid}
         />
       )}
       {uploadOpen && (


### PR DESCRIPTION
Ref #147 

This solution uses an initial handshake with the backend to get a session ID then individually submits each image

The component tracks the success or failure of each file transfer and allows retrying the failed ones

Features
- Progress bar
- Success Indicator
- Retry Failed transfers

![Screenshot 2024-06-23 111640](https://github.com/ai-cfia/nachet-frontend/assets/78883122/92ca66f3-0caf-4a27-a3d4-0bdb7a0490b2)

![chrome_JI4Ta31yr4](https://github.com/ai-cfia/nachet-frontend/assets/78883122/ecf9b1bc-d5c6-4ad4-a56a-7f6bdc8e1a91)
