### PR TITLE
167 Annotation init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/_versions.ts
+++ b/src/_versions.ts
@@ -11,8 +11,8 @@ export interface TsAppVersion {
 export const versions: TsAppVersion = {
     version: '0.9.0',
     name: 'nachet-frontend',
-    versionDate: '2024-06-22T20:47:06.767Z',
-    gitCommitHash: '',
-    versionLong: '0.9.0-',
+    versionDate: '2024-07-05T03:26:49.628Z',
+    gitCommitHash: '637ff43',
+    versionLong: '0.9.0-637ff43',
 };
 export default versions;

--- a/src/common/imageutils.ts
+++ b/src/common/imageutils.ts
@@ -37,8 +37,8 @@ export const getUnscaledCoordinates = (
   const scaleFactorHeight = itemHeight / containerHeight;
   const topX = box.left * scaleFactorWidth;
   const topY = box.top * scaleFactorHeight;
-  const bottomX = box.left + box.minWidth * scaleFactorWidth;
-  const bottomY = box.top + box.minHeight * scaleFactorHeight;
+  const bottomX = (box.left + box.minWidth) * scaleFactorWidth;
+  const bottomY = (box.top + box.minHeight) * scaleFactorHeight;
   return {
     topX,
     topY,

--- a/src/components/body/feedback_form/FeedbackForm.tsx
+++ b/src/components/body/feedback_form/FeedbackForm.tsx
@@ -243,7 +243,7 @@ export const NegativeFeedbackForm = (
   return (
     <Draggable
       defaultPosition={{
-        x: position.left + position.minWidth + 10,
+        x: position.left - parseInt(formWidth.slice(0, -2)) - 10,
         y: position.top,
       }}
       bounds="parent"

--- a/src/components/body/feedback_form/FeedbackForm.tsx
+++ b/src/components/body/feedback_form/FeedbackForm.tsx
@@ -117,6 +117,8 @@ export const NegativeFeedbackForm = (
     };
   }, []);
 
+  const formWidth = "300px";
+
   const { inference, position, classList, onCancel, onSubmit } = props;
   const [selectedClass, setSelectedClass] = useState<ClassData>(defaultClass);
   const [comment, setComment] = useState<string>(reasons[2]);
@@ -211,10 +213,10 @@ export const NegativeFeedbackForm = (
   return (
     <Draggable
       defaultPosition={{
-        x: position.left,
+        x: position.left + position.minWidth + 10,
         y: position.top,
       }}
-      // bounds="parent"
+      bounds="parent"
       disabled={false}
     >
       <Box
@@ -225,7 +227,7 @@ export const NegativeFeedbackForm = (
           backgroundColor: "white",
           border: "2px solid black",
           padding: "10px",
-          minWidth: "300px",
+          minWidth: formWidth,
           minHeight: "5px",
           borderRadius: "5px",
         }}

--- a/src/components/body/feedback_form/FeedbackForm.tsx
+++ b/src/components/body/feedback_form/FeedbackForm.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   IconButton,
   FormControl,
-  // FormLabel,
   Button,
   Autocomplete,
   TextField,
@@ -12,6 +11,14 @@ import {
   MenuItem,
   SelectChangeEvent,
   FilterOptionsState,
+  Paper,
+  TableContainer,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableHead,
+  Typography,
 } from "@mui/material";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
@@ -71,7 +78,10 @@ export const SimpleFeedbackForm = (
           flexWrap: "wrap",
         }}
       >
-        <IconButton sx={{marginRight: "15px"}} onClick={handlePositiveFeedback}>
+        <IconButton
+          sx={{ marginRight: "15px" }}
+          onClick={handlePositiveFeedback}
+        >
           <CheckCircleOutlinedIcon
             sx={{
               color: "green",
@@ -106,7 +116,13 @@ export const NegativeFeedbackForm = (
   /* TODO: update when backend is defined Section stub convert to prop or use state when backend defined */
 
   const reasons = useMemo(() => {
-    return ["No Seed", "Multi Seed", "Wrong Seed", "Wrong Seed not in List"];
+    return [
+      "Seed not Detected",
+      "Wrong Seed",
+      "No Seed",
+      "Multi Seed",
+      "Wrong Seed not in List",
+    ];
   }, []);
   /* Section stub convert to prop or use state when backend defined */
 
@@ -129,7 +145,7 @@ export const NegativeFeedbackForm = (
     isNewAnnotation,
   } = props;
   const [selectedClass, setSelectedClass] = useState<ClassData>(defaultClass);
-  const [comment, setComment] = useState<string>(reasons[2]);
+  const [comment, setComment] = useState<string>(reasons[1]);
 
   const filter = createFilterOptions<ClassData>();
 
@@ -218,6 +234,12 @@ export const NegativeFeedbackForm = (
     }
   }, [comment]);
 
+  useEffect(() => {
+    if (isNewAnnotation) {
+      setComment(reasons[0]);
+    }
+  }, [isNewAnnotation, reasons]);
+
   return (
     <Draggable
       defaultPosition={{
@@ -237,10 +259,51 @@ export const NegativeFeedbackForm = (
           padding: "10px",
           minWidth: formWidth,
           minHeight: "5px",
-          borderRadius: "5px",
+          borderRadius: "10px",
+          justifyContent: "center",
         }}
       >
-        <FormControl size="small" sx={{ width: "100%" }}>
+        <FormControl size="small" sx={{ width: "100%", alignItems: "center" }}>
+          <Typography variant="h5" sx={{ textAlign: "center", marginBottom: "10px" }}>
+            Feedback
+            </Typography>
+
+          <TableContainer component={Paper}  sx={{ maxWidth: "fit-content" }}>
+            <Table sx={{ maxWidth: "fit-content" }}  size="small" aria-label="Bounding Box">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Bounding Box</TableCell>
+                  <TableCell>_</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow>
+                  <TableCell>TopX</TableCell>
+                  <TableCell sx={{textAlign: "right"}}>
+                    {inference.boxes[0].box.topX.toFixed(2)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>TopY</TableCell>
+                  <TableCell sx={{textAlign: "right"}}>
+                    {inference.boxes[0].box.topY.toFixed(2)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>BottomX</TableCell>
+                  <TableCell sx={{textAlign: "right"}}>
+                    {inference.boxes[0].box.bottomX.toFixed(2)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>BottomY</TableCell>
+                  <TableCell sx={{textAlign: "right"}}>
+                    {inference.boxes[0].box.bottomY.toFixed(2)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
           <Autocomplete
             id="feedback-class"
             renderInput={(params) => <TextField {...params} label="Class" />}
@@ -263,26 +326,27 @@ export const NegativeFeedbackForm = (
             }}
             disabled={comment === "No Seed"}
           />
-          {!isNewAnnotation && (
-            <Select
-              labelId="comment-select-label"
-              id="feedback-comment"
-              value={comment}
-              label="Feedback Comment"
-              onChange={handleCommentChange}
-              sx={{
-                marginTop: "20px",
-              }}
-            >
-              {reasons.map((reason, index) => {
-                return (
-                  <MenuItem key={index} value={reason}>
-                    {reason}
-                  </MenuItem>
-                );
-              })}
-            </Select>
-          )}
+
+          <Select
+            disabled={isNewAnnotation}
+            labelId="comment-select-label"
+            id="feedback-comment"
+            value={comment}
+            label="Feedback Comment"
+            onChange={handleCommentChange}
+            sx={{
+              marginTop: "20px",
+              minWidth: "100%",
+            }}
+          >
+            {reasons.map((reason, index) => {
+              return (
+                <MenuItem key={index} value={reason}>
+                  {reason}
+                </MenuItem>
+              );
+            })}
+          </Select>
 
           <Box
             sx={{
@@ -291,6 +355,7 @@ export const NegativeFeedbackForm = (
               justifyContent: "space-evenly",
               alignItems: "center",
               marginTop: "20px",
+              minWidth: "100%",
             }}
           >
             <Button

--- a/src/components/body/feedback_form/FeedbackForm.tsx
+++ b/src/components/body/feedback_form/FeedbackForm.tsx
@@ -71,7 +71,7 @@ export const SimpleFeedbackForm = (
           flexWrap: "wrap",
         }}
       >
-        <IconButton size="small" onClick={handlePositiveFeedback}>
+        <IconButton sx={{marginRight: "15px"}} onClick={handlePositiveFeedback}>
           <CheckCircleOutlinedIcon
             sx={{
               color: "green",
@@ -97,6 +97,7 @@ interface NegativeFeedbackFormProps {
   classList: ClassData[];
   onCancel: () => void;
   onSubmit: (feedbackDataNegative: FeedbackDataNegative) => void;
+  isNewAnnotation: boolean;
 }
 
 export const NegativeFeedbackForm = (
@@ -119,7 +120,14 @@ export const NegativeFeedbackForm = (
 
   const formWidth = "300px";
 
-  const { inference, position, classList, onCancel, onSubmit } = props;
+  const {
+    inference,
+    position,
+    classList,
+    onCancel,
+    onSubmit,
+    isNewAnnotation,
+  } = props;
   const [selectedClass, setSelectedClass] = useState<ClassData>(defaultClass);
   const [comment, setComment] = useState<string>(reasons[2]);
 
@@ -255,24 +263,26 @@ export const NegativeFeedbackForm = (
             }}
             disabled={comment === "No Seed"}
           />
-          <Select
-            labelId="comment-select-label"
-            id="feedback-comment"
-            value={comment}
-            label="Feedback Comment"
-            onChange={handleCommentChange}
-            sx={{
-              marginTop: "20px",
-            }}
-          >
-            {reasons.map((reason, index) => {
-              return (
-                <MenuItem key={index} value={reason}>
-                  {reason}
-                </MenuItem>
-              );
-            })}
-          </Select>
+          {!isNewAnnotation && (
+            <Select
+              labelId="comment-select-label"
+              id="feedback-comment"
+              value={comment}
+              label="Feedback Comment"
+              onChange={handleCommentChange}
+              sx={{
+                marginTop: "20px",
+              }}
+            >
+              {reasons.map((reason, index) => {
+                return (
+                  <MenuItem key={index} value={reason}>
+                    {reason}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          )}
 
           <Box
             sx={{

--- a/src/components/body/feedback_form/FeedbackForm.tsx
+++ b/src/components/body/feedback_form/FeedbackForm.tsx
@@ -264,12 +264,19 @@ export const NegativeFeedbackForm = (
         }}
       >
         <FormControl size="small" sx={{ width: "100%", alignItems: "center" }}>
-          <Typography variant="h5" sx={{ textAlign: "center", marginBottom: "10px" }}>
+          <Typography
+            variant="h5"
+            sx={{ textAlign: "center", marginBottom: "10px" }}
+          >
             Feedback
-            </Typography>
+          </Typography>
 
-          <TableContainer component={Paper}  sx={{ maxWidth: "fit-content" }}>
-            <Table sx={{ maxWidth: "fit-content" }}  size="small" aria-label="Bounding Box">
+          <TableContainer component={Paper} sx={{ maxWidth: "fit-content" }}>
+            <Table
+              sx={{ maxWidth: "fit-content" }}
+              size="small"
+              aria-label="Bounding Box"
+            >
               <TableHead>
                 <TableRow>
                   <TableCell>Bounding Box</TableCell>
@@ -279,25 +286,25 @@ export const NegativeFeedbackForm = (
               <TableBody>
                 <TableRow>
                   <TableCell>TopX</TableCell>
-                  <TableCell sx={{textAlign: "right"}}>
+                  <TableCell sx={{ textAlign: "right" }}>
                     {inference.boxes[0].box.topX.toFixed(2)}
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>TopY</TableCell>
-                  <TableCell sx={{textAlign: "right"}}>
+                  <TableCell sx={{ textAlign: "right" }}>
                     {inference.boxes[0].box.topY.toFixed(2)}
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>BottomX</TableCell>
-                  <TableCell sx={{textAlign: "right"}}>
+                  <TableCell sx={{ textAlign: "right" }}>
                     {inference.boxes[0].box.bottomX.toFixed(2)}
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>BottomY</TableCell>
-                  <TableCell sx={{textAlign: "right"}}>
+                  <TableCell sx={{ textAlign: "right" }}>
                     {inference.boxes[0].box.bottomY.toFixed(2)}
                   </TableCell>
                 </TableRow>

--- a/src/components/body/feedback_form/FreeformBox.tsx
+++ b/src/components/body/feedback_form/FreeformBox.tsx
@@ -2,7 +2,7 @@ import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { NumberSize, Resizable } from "re-resizable";
 import { Box, IconButton } from "@mui/material";
 import OpenWithOutlinedIcon from "@mui/icons-material/OpenWithOutlined";
-import SaveIcon from '@mui/icons-material/Save';
+import SaveIcon from "@mui/icons-material/Save";
 import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
 import OpenInFullOutlinedIcon from "@mui/icons-material/OpenInFullOutlined";
 import { useState } from "react";

--- a/src/components/body/feedback_form/FreeformBox.tsx
+++ b/src/components/body/feedback_form/FreeformBox.tsx
@@ -124,10 +124,11 @@ const FreeformBox = (props: FreeformBoxProps) => {
             )}
           </IconButton>
           <IconButton
-            size="small"
             sx={{
               ...buttonStyle,
               color: "green",
+              marginRight: "10px",
+              marginLeft: "10px",
             }}
             onClick={handleSubmit}
           >
@@ -135,7 +136,6 @@ const FreeformBox = (props: FreeformBoxProps) => {
           </IconButton>
 
           <IconButton
-            size="small"
             sx={{
               ...buttonStyle,
               color: "red",

--- a/src/components/body/feedback_form/FreeformBox.tsx
+++ b/src/components/body/feedback_form/FreeformBox.tsx
@@ -12,10 +12,11 @@ interface FreeformBoxProps {
   position: BoxCSS;
   onSubmit: (boxPosition: BoxCSS) => void;
   onCancel: () => void;
+  isNewAnnotation: boolean;
 }
 
 const FreeformBox = (props: FreeformBoxProps) => {
-  const { onSubmit, onCancel, position } = props;
+  const { onSubmit, onCancel, position, isNewAnnotation } = props;
   const [dragEnabled, setDragEnabled] = useState(true);
   const [topX, setTopX] = useState(position.left);
   const [topY, setTopY] = useState(position.top);
@@ -123,27 +124,31 @@ const FreeformBox = (props: FreeformBoxProps) => {
               <OpenInFullOutlinedIcon />
             )}
           </IconButton>
-          <IconButton
-            sx={{
-              ...buttonStyle,
-              color: "green",
-              marginRight: "10px",
-              marginLeft: "10px",
-            }}
-            onClick={handleSubmit}
-          >
-            <CheckCircleOutlinedIcon />
-          </IconButton>
+          {!isNewAnnotation && (
+            <>
+              <IconButton
+                sx={{
+                  ...buttonStyle,
+                  color: "green",
+                  marginRight: "10px",
+                  marginLeft: "10px",
+                }}
+                onClick={handleSubmit}
+              >
+                <CheckCircleOutlinedIcon />
+              </IconButton>
 
-          <IconButton
-            sx={{
-              ...buttonStyle,
-              color: "red",
-            }}
-            onClick={onCancel}
-          >
-            <CancelOutlinedIcon />
-          </IconButton>
+              <IconButton
+                sx={{
+                  ...buttonStyle,
+                  color: "red",
+                }}
+                onClick={onCancel}
+              >
+                <CancelOutlinedIcon />
+              </IconButton>
+            </>
+          )}
         </Box>
       </Resizable>
     </Draggable>

--- a/src/components/body/feedback_form/FreeformBox.tsx
+++ b/src/components/body/feedback_form/FreeformBox.tsx
@@ -2,7 +2,7 @@ import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { NumberSize, Resizable } from "re-resizable";
 import { Box, IconButton } from "@mui/material";
 import OpenWithOutlinedIcon from "@mui/icons-material/OpenWithOutlined";
-import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import SaveIcon from '@mui/icons-material/Save';
 import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
 import OpenInFullOutlinedIcon from "@mui/icons-material/OpenInFullOutlined";
 import { useState } from "react";
@@ -21,6 +21,7 @@ const FreeformBox = (props: FreeformBoxProps) => {
   const [topY, setTopY] = useState(position.top);
   const [width, setWidth] = useState(position.minWidth);
   const [height, setHeight] = useState(position.minHeight);
+  const [changesSaved, setChangesSaved] = useState(true);
 
   const buttonStyle = {
     borderRadius: "0",
@@ -34,6 +35,7 @@ const FreeformBox = (props: FreeformBoxProps) => {
   ) => {
     setTopX(dragElement.x);
     setTopY(dragElement.y);
+    setChangesSaved(false);
   };
 
   const handleResizeStop = (
@@ -44,6 +46,7 @@ const FreeformBox = (props: FreeformBoxProps) => {
   ) => {
     setWidth(width + delta.width);
     setHeight(height + delta.height);
+    setChangesSaved(false);
   };
 
   const handleSubmit = () => {
@@ -55,6 +58,7 @@ const FreeformBox = (props: FreeformBoxProps) => {
       maxWidth: width,
       maxHeight: height,
     };
+    setChangesSaved(true);
     onSubmit(currPosition);
   };
 
@@ -127,13 +131,13 @@ const FreeformBox = (props: FreeformBoxProps) => {
           <IconButton
             sx={{
               ...buttonStyle,
-              color: "green",
+              color: changesSaved ? "green" : "grey",
               marginRight: "10px",
               marginLeft: "10px",
             }}
             onClick={handleSubmit}
           >
-            <CheckCircleOutlinedIcon />
+            <SaveIcon />
           </IconButton>
 
           <IconButton

--- a/src/components/body/feedback_form/FreeformBox.tsx
+++ b/src/components/body/feedback_form/FreeformBox.tsx
@@ -12,11 +12,10 @@ interface FreeformBoxProps {
   position: BoxCSS;
   onSubmit: (boxPosition: BoxCSS) => void;
   onCancel: () => void;
-  isNewAnnotation: boolean;
 }
 
 const FreeformBox = (props: FreeformBoxProps) => {
-  const { onSubmit, onCancel, position, isNewAnnotation } = props;
+  const { onSubmit, onCancel, position } = props;
   const [dragEnabled, setDragEnabled] = useState(true);
   const [topX, setTopX] = useState(position.left);
   const [topY, setTopY] = useState(position.top);
@@ -124,31 +123,28 @@ const FreeformBox = (props: FreeformBoxProps) => {
               <OpenInFullOutlinedIcon />
             )}
           </IconButton>
-          {!isNewAnnotation && (
-            <>
-              <IconButton
-                sx={{
-                  ...buttonStyle,
-                  color: "green",
-                  marginRight: "10px",
-                  marginLeft: "10px",
-                }}
-                onClick={handleSubmit}
-              >
-                <CheckCircleOutlinedIcon />
-              </IconButton>
 
-              <IconButton
-                sx={{
-                  ...buttonStyle,
-                  color: "red",
-                }}
-                onClick={onCancel}
-              >
-                <CancelOutlinedIcon />
-              </IconButton>
-            </>
-          )}
+          <IconButton
+            sx={{
+              ...buttonStyle,
+              color: "green",
+              marginRight: "10px",
+              marginLeft: "10px",
+            }}
+            onClick={handleSubmit}
+          >
+            <CheckCircleOutlinedIcon />
+          </IconButton>
+
+          <IconButton
+            sx={{
+              ...buttonStyle,
+              color: "red",
+            }}
+            onClick={onCancel}
+          >
+            <CancelOutlinedIcon />
+          </IconButton>
         </Box>
       </Resizable>
     </Draggable>

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -254,6 +254,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
 
   const enterFeedbackMode = (index: number, boxPosition: BoxCSS) => {
     if (imageData == null) {
+      exitFeedbackMode();
       return;
     }
 

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -216,6 +216,22 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
       });
   };
 
+  const submitNewAnnotation = (feedbackDataNegative: FeedbackDataNegative) => {
+    if (imageData === null) {
+      return;
+    }
+    console.log("Submitting new annotation");
+
+    sendNewAnnotation(feedbackDataNegative, backendUrl)
+      .then(() => {
+        console.log("New Annotation submitted successfully");
+        exitFeedbackMode();
+      })
+      .catch((error) => {
+        console.error("Error submitting new annotation: ", error);
+      });
+  };
+
   const handleFreeformSubmit = (box: BoxCSS) => {
     setScaledFeedbackBox(box);
     setInferenceForRevision((prev) => {

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -12,6 +12,7 @@ import DownloadIcon from "@mui/icons-material/Download";
 import CropFreeIcon from "@mui/icons-material/CropFree";
 import ToggleButton from "../buttons/ToggleButton";
 import DonutSmallIcon from "@mui/icons-material/DonutSmall";
+import FormatShapesOutlinedIcon from "@mui/icons-material/FormatShapesOutlined";
 
 // Import a loading icon component (ensure you have this)
 import CircularProgress from "@mui/material/CircularProgress";
@@ -128,12 +129,12 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
   const height = windowSize.height * 0.605;
 
   const defaultBoxPosition: BoxCSS = {
-    minWidth: width,
-    minHeight: height,
-    maxWidth: width,
-    maxHeight: height,
-    left: 0,
-    top: 0,
+    minWidth: 100,
+    minHeight: 100,
+    maxWidth: 100,
+    maxHeight: 100,
+    left: width / 2 - 50,
+    top: height / 2 - 50,
   };
 
   const [imageData, setImageData] = useState<Images | null>(null);
@@ -237,6 +238,10 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
     });
   };
 
+  const handleAnnotate = () => {
+    enterFeedbackMode(imageIndex, null);
+  };
+
   const exitFeedbackMode = () => {
     toggleShowInference(true);
     setFeedbackMode(false);
@@ -245,16 +250,39 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
   };
 
   const enterFeedbackMode = (
-    index: number | null,
+    index: number,
     boxPosition: BoxCSS | null,
   ) => {
-    if (imageData == null) {
-      return;
-    }
-
-    if (index == null || boxPosition == null) {
+    if (boxPosition == null) {
       setScaledFeedbackBox(defaultBoxPosition);
+      const image = imageCache.find((image) => image.index === imageIndex)
+      if (image == null) {
+        return;
+      };
+      const unscaledBox = getUnscaledCoordinates(
+        width,
+        height,
+        image.imageDims[0],
+        image.imageDims[1],
+        defaultBoxPosition,
+      );
+      setInferenceForRevision({
+        userId: uuid,
+        inferenceId: "",
+        boxes: [
+          {
+            classId: "",
+            label: "",
+            boxId: "",
+            box: unscaledBox,
+            comment: "",
+          },
+        ],
+      });
     } else {
+      if (imageData == null) {
+        return;
+      }
       setScaledFeedbackBox(boxPosition);
       setInferenceForRevision({
         userId: uuid,
@@ -371,6 +399,14 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
           disabled={isWebcamActive} // Disable when the webcam is active
           onClick={() => {
             handleInference();
+          }}
+        />
+        <ButtonMicroscopeFeed
+          label="ANNOTATE"
+          icon={<FormatShapesOutlinedIcon color="inherit" style={iconStyle} />}
+          disabled={isWebcamActive} // Disable when the webcam is active
+          onClick={() => {
+            handleAnnotate();
           }}
         />
       </Box>

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -139,6 +139,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
 
   const [imageData, setImageData] = useState<Images | null>(null);
   const [feedbackMode, setFeedbackMode] = useState<boolean>(false);
+  const [isNewAnnotation, setIsNewAnnotation] = useState<boolean>(false);
   const [scaledFeedbackBox, setScaledFeedbackBox] = useState<BoxCSS | null>(
     null,
   );
@@ -239,6 +240,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
   };
 
   const handleAnnotate = () => {
+    setIsNewAnnotation(true);
     enterFeedbackMode(imageIndex, null);
   };
 
@@ -247,6 +249,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
     setFeedbackMode(false);
     setInferenceForRevision(null);
     setScaledFeedbackBox(null);
+    setIsNewAnnotation(false);
   };
 
   const enterFeedbackMode = (
@@ -396,7 +399,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
         <ButtonMicroscopeFeed
           label="CLASSIFY"
           icon={<CropFreeIcon color="inherit" style={iconStyle} />}
-          disabled={isWebcamActive} // Disable when the webcam is active
+          disabled={isWebcamActive || imageCache.length == 0} // Disable when the webcam is active
           onClick={() => {
             handleInference();
           }}
@@ -404,7 +407,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
         <ButtonMicroscopeFeed
           label="ANNOTATE"
           icon={<FormatShapesOutlinedIcon color="inherit" style={iconStyle} />}
-          disabled={isWebcamActive} // Disable when the webcam is active
+          disabled={isWebcamActive || imageCache.length == 0} // Disable when the webcam is active
           onClick={() => {
             handleAnnotate();
           }}
@@ -419,11 +422,13 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
               classList={classList}
               onCancel={exitFeedbackMode}
               onSubmit={submitNegativeFeedback}
+              isNewAnnotation={isNewAnnotation}
             />
             <FreeformBox
               position={scaledFeedbackBox}
               onCancel={exitFeedbackMode}
               onSubmit={handleFreeformSubmit}
+              isNewAnnotation={isNewAnnotation}
             />
           </>
         )}

--- a/src/components/body/scaled_inference_box/ScaledInferenceBox.tsx
+++ b/src/components/body/scaled_inference_box/ScaledInferenceBox.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@mui/material";
 import { MouseEvent, useState } from "react";
-import { BoxCSS, Images } from "../../../common/types";
+import { BoxCSS, InferenceBox } from "../../../common/types";
 import { SimpleFeedbackForm } from "../feedback_form";
 import { getScaledBounds } from "../../../common";
 
@@ -8,14 +8,14 @@ const ScaledInferenceBox = (props: {
   index: number;
   imageWidth: number;
   imageHeight: number;
-  box: Images["boxes"][0];
+  box: InferenceBox;
   canvasWidth: number;
   canvasHeight: number;
   label: string;
   visible: boolean;
   submitPositiveFeedback: (index: number) => void;
   handleNegativeFeedback: (
-    index: number | null,
+    index: number,
     boxPosition: BoxCSS | null,
   ) => void;
 }): JSX.Element => {

--- a/src/components/body/scaled_inference_box/ScaledInferenceBox.tsx
+++ b/src/components/body/scaled_inference_box/ScaledInferenceBox.tsx
@@ -14,10 +14,7 @@ const ScaledInferenceBox = (props: {
   label: string;
   visible: boolean;
   submitPositiveFeedback: (index: number) => void;
-  handleNegativeFeedback: (
-    index: number,
-    boxPosition: BoxCSS,
-  ) => void;
+  handleNegativeFeedback: (index: number, boxPosition: BoxCSS) => void;
 }): JSX.Element => {
   const {
     index,

--- a/src/components/body/scaled_inference_box/ScaledInferenceBox.tsx
+++ b/src/components/body/scaled_inference_box/ScaledInferenceBox.tsx
@@ -16,7 +16,7 @@ const ScaledInferenceBox = (props: {
   submitPositiveFeedback: (index: number) => void;
   handleNegativeFeedback: (
     index: number,
-    boxPosition: BoxCSS | null,
+    boxPosition: BoxCSS,
   ) => void;
 }): JSX.Element => {
   const {


### PR DESCRIPTION
Closes #167 
Closes #129 

Implement Annotation mode - Allow a user to create a new bounding box

Fixes an issue where the bounding box isn't rescaled properly to the original image dimensions
UI changes to the feedback form to indicate if bounding box changes have been saved
Spread out approve reject to lessen misclicks
Lock classify and annotate if there is no image loaded
Show feedback form to the left of bounding box and constrain to feed canvas

![chrome_4wER37uVjh](https://github.com/ai-cfia/nachet-frontend/assets/78883122/f72480a3-09b5-4f49-a8fd-b862827ca348)

![chrome_lLoPsjVrNP](https://github.com/ai-cfia/nachet-frontend/assets/78883122/40ed3b65-04b3-4710-b8da-49a7281013c0)
