### PR TITLE
update microscope feed after feedback

### DIFF
--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -188,7 +188,7 @@ export const fetchModelMetadata = async (
 export const sendFeedbackNewBox = async (
   feedbackData: FeedbackDataNegative,
   backendUrl: string,
-): Promise<void> => {
+): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
@@ -201,13 +201,13 @@ export const sendFeedbackNewBox = async (
     },
     data: feedbackData,
   };
-  return handleAxios(request);
+  return handleAxios<ApiInferenceData>(request);
 };
 
 export const sendPositiveFeedback = async (
   feedbackData: FeedbackDataPositive,
   backendUrl: string,
-): Promise<void> => {
+): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
@@ -220,13 +220,13 @@ export const sendPositiveFeedback = async (
     },
     data: feedbackData,
   };
-  return handleAxios(request);
+  return handleAxios<ApiInferenceData>(request);
 };
 
 export const sendNegativeFeedback = async (
   feedbackData: FeedbackDataNegative,
   backendUrl: string,
-): Promise<void> => {
+): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
@@ -239,7 +239,7 @@ export const sendNegativeFeedback = async (
     },
     data: feedbackData,
   };
-  return handleAxios(request);
+  return handleAxios<ApiInferenceData>(request);
 };
 
 export const requestUUID = async (

--- a/src/common/cacheutils.ts
+++ b/src/common/cacheutils.ts
@@ -367,7 +367,9 @@ export const loadResultsToCache = (
   newCache[index] = {
     ...newCache[index],
     scores: inferenceData.boxes.map((box) => box.score),
-    classifications: inferenceData.boxes.map((box) => box.label.replace(/^\d+\s+/, '')),
+    classifications: inferenceData.boxes.map((box) =>
+      box.label.replace(/^\d+\s+/, ""),
+    ),
     boxes: inferenceData.boxes.map((box) => {
       return {
         ...box.box,

--- a/src/common/cacheutils.ts
+++ b/src/common/cacheutils.ts
@@ -367,7 +367,7 @@ export const loadResultsToCache = (
   newCache[index] = {
     ...newCache[index],
     scores: inferenceData.boxes.map((box) => box.score),
-    classifications: inferenceData.boxes.map((box) => box.label),
+    classifications: inferenceData.boxes.map((box) => box.label.replace(/^\d+\s+/, '')),
     boxes: inferenceData.boxes.map((box) => {
       return {
         ...box.box,

--- a/src/common/tests/loadresultstocache.test.ts
+++ b/src/common/tests/loadresultstocache.test.ts
@@ -22,6 +22,7 @@ describe("loadResultsToCache", () => {
     filename: "test",
     imageId: "test",
     inference_id: "test",
+    models: [{ name: "test", version: 0 }],
     boxes: [
       {
         score: 0.1,
@@ -96,6 +97,7 @@ describe("loadResultsToCache", () => {
       filename: "test",
       imageId: "test",
       inference_id: "test",
+      models: [{ name: "test", version: 0 }],
       boxes: [
         {
           score: 0.1,

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -17,7 +17,7 @@ export interface ApiInferenceData {
     seed_name: number;
   };
   totalBoxes: number;
-  models: Array<{name: string; version: number}>;
+  models: Array<{ name: string; version: number }>;
 }
 export interface Images {
   index: number;

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -17,6 +17,7 @@ export interface ApiInferenceData {
     seed_name: number;
   };
   totalBoxes: number;
+  models: Array<{name: string; version: number}>;
 }
 export interface Images {
   index: number;

--- a/src/components/body/classification_results/index.tsx
+++ b/src/components/body/classification_results/index.tsx
@@ -235,7 +235,7 @@ const ClassificationResults: React.FC<params> = (props) => {
                       handleSelect(key);
                     }}
                   >
-                    {key.split(" ").slice(1).join(" ")}
+                    {key}
                   </TableCell>
                   <TableCell
                     align="right"
@@ -384,7 +384,7 @@ const ClassificationResults: React.FC<params> = (props) => {
                                   paddingBottom: "0.5vh",
                                 }}
                               >
-                                {prediction.split(" ").slice(1).join(" ")}
+                                {prediction}
                               </TableCell>
                               <TableCell
                                 align="right"

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -29,6 +29,7 @@ import {
   requestClassList,
   sendNegativeFeedback,
   sendPositiveFeedback,
+  loadResultsToCache,
 } from "../../../common";
 import { FreeformBox, NegativeFeedbackForm } from "../feedback_form";
 import { getUnscaledCoordinates } from "../../../common/imageutils";
@@ -45,6 +46,7 @@ interface MicroscopeFeedProps {
   setUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setSwitchModelOpen: React.Dispatch<React.SetStateAction<boolean>>;
   imageCache: Images[];
+  setImageCache : React.Dispatch<React.SetStateAction<Images[]>>;
   handleInference: () => void;
   imageIndex: number;
   isWebcamActive: boolean;
@@ -116,6 +118,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
     setUploadOpen,
     setSwitchModelOpen,
     imageCache,
+    setImageCache,
     handleInference,
     imageIndex,
     isWebcamActive,
@@ -201,8 +204,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
     setApiLoading(true);
     setApiResultDismissed(false);
     sendPositiveFeedback(feedbackDataPositive, backendUrl)
-      .then(() => {
+      .then((response) => {
         console.log("Positive Feedback submitted successfully");
+        setImageCache(loadResultsToCache(response, imageCache, imageIndex));
         setApiSuccess(true);
       })
       .catch((error) => {
@@ -225,8 +229,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps): JSX.Element => {
     setApiLoading(true);
     setApiResultDismissed(false);
     sendNegativeFeedback(feedbackDataNegative, backendUrl)
-      .then(() => {
+      .then((response) => {
         console.log("Negative Feedback submitted successfully");
+        setImageCache(loadResultsToCache(response, imageCache, imageIndex));
         setApiSuccess(true);
       })
       .catch((error) => {

--- a/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -46,7 +46,7 @@ interface MicroscopeFeedProps {
   setUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setSwitchModelOpen: React.Dispatch<React.SetStateAction<boolean>>;
   imageCache: Images[];
-  setImageCache : React.Dispatch<React.SetStateAction<Images[]>>;
+  setImageCache: React.Dispatch<React.SetStateAction<Images[]>>;
   handleInference: () => void;
   imageIndex: number;
   isWebcamActive: boolean;

--- a/src/pages/classifier/index.tsx
+++ b/src/pages/classifier/index.tsx
@@ -12,7 +12,7 @@ import ClassificationResults from "../../components/body/classification_results"
 import ImageCache from "../../components/body/image_cache";
 import StorageDirectory from "../../components/body/directory_list";
 import MicroscopeFeed from "../../components/body/microscope_feed";
-import { AzureStorageDirectoryItem, Images, } from "../../common/types";
+import { AzureStorageDirectoryItem, Images } from "../../common/types";
 
 interface params {
   imageSrc: string;
@@ -21,7 +21,7 @@ interface params {
   setSaveOpen: React.Dispatch<React.SetStateAction<boolean>>;
   capture: () => void;
   savedImages: any[];
-  setImageCache : React.Dispatch<React.SetStateAction<Images[]>>;
+  setImageCache: React.Dispatch<React.SetStateAction<Images[]>>;
   clearImageCache: () => void;
   setImageIndex: React.Dispatch<React.SetStateAction<number>>;
   setBatchUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/pages/classifier/index.tsx
+++ b/src/pages/classifier/index.tsx
@@ -12,7 +12,7 @@ import ClassificationResults from "../../components/body/classification_results"
 import ImageCache from "../../components/body/image_cache";
 import StorageDirectory from "../../components/body/directory_list";
 import MicroscopeFeed from "../../components/body/microscope_feed";
-import { AzureStorageDirectoryItem } from "../../common/types";
+import { AzureStorageDirectoryItem, Images, } from "../../common/types";
 
 interface params {
   imageSrc: string;
@@ -21,6 +21,7 @@ interface params {
   setSaveOpen: React.Dispatch<React.SetStateAction<boolean>>;
   capture: () => void;
   savedImages: any[];
+  setImageCache : React.Dispatch<React.SetStateAction<Images[]>>;
   clearImageCache: () => void;
   setImageIndex: React.Dispatch<React.SetStateAction<number>>;
   setBatchUploadOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -74,6 +75,7 @@ const Classifier: React.FC<params> = (props) => {
             handleInference={props.handleInference}
             setSwitchModelOpen={props.setSwitchModelOpen}
             imageCache={props.savedImages}
+            setImageCache={props.setImageCache}
             imageIndex={props.imageIndex}
             setBatchUploadOpen={props.setBatchUploadOpen}
             setUploadOpen={props.setUploadOpen}

--- a/src/root/body/body.tsx
+++ b/src/root/body/body.tsx
@@ -418,6 +418,7 @@ const Body: React.FC<params> = (props) => {
         setSaveOpen={setSaveOpen}
         capture={captureFeed}
         savedImages={imageCache}
+        setImageCache={setImageCache}
         clearImageCache={clearCache}
         canvasRef={canvasRef}
         removeImage={removeFromCache}


### PR DESCRIPTION
ref #182 

- Cache the inference data received after a feedback call to update the microscope feed component
- Rename classification labels so that the difference between the one with numbers and the others is not visible